### PR TITLE
Update process_request to match new method signature

### DIFF
--- a/lib/elasticsearch/tracer/transport.rb
+++ b/lib/elasticsearch/tracer/transport.rb
@@ -9,7 +9,7 @@ module Elasticsearch
         @wrapped = transport
       end
 
-      def perform_request(method, path, params={}, body=nil)
+      def perform_request(method, path, params={}, body=nil, headers=nil)
         span = tracer.start_span(method,
                                  child_of: active_span.respond_to?(:call) ? active_span.call : active_span,
                                  tags: {
@@ -22,7 +22,7 @@ module Elasticsearch
                                   'elasticsearch.params' => URI.encode_www_form(params)
                                  })
 
-        response = @wrapped.perform_request(method, path, params, body)
+        response = @wrapped.perform_request(method, path, params, body, headers)
         span.set_tag('http.status_code', response.status)
 
         response

--- a/spec/elasticsearch/tracer/transport_spec.rb
+++ b/spec/elasticsearch/tracer/transport_spec.rb
@@ -113,8 +113,8 @@ RSpec.describe Elasticsearch::Tracer::Transport do
       @custom_block = block
     end
 
-    def perform_request(method, path, params={}, body=nil)
-      @custom_block ? @custom_block.call(method, path, params, body) : SuccessfullResponse
+    def perform_request(method, path, params={}, body=nil, headers=nil)
+      @custom_block ? @custom_block.call(method, path, params, body, headers) : SuccessfullResponse
     end
   end
 end


### PR DESCRIPTION
The 6.x client has an additional optional parameter, `headers`. The transport class has been updated to match that.

It is still compatible with the older API